### PR TITLE
Fixed missing dependency: chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/GochoMugo/is-my-world-spinning#readme",
   "dependencies": {
+    "chalk": "^1.1.3",
     "log-update": "^1.0.2",
     "require-all": "^2.0.0",
     "superagent": "^2.2.0",


### PR DESCRIPTION
Installing the package globally via npm and running the utility returns: `Error: Cannot find module 'chalk'`

I have published a test variation @ `npm install -g is-my-world-spinning-test` to see the changes in this PR.
